### PR TITLE
Upgrade to frictionless v5, min. Python 3.7 (#2)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ package_dir =
     = src
 include_package_data = true
 zip_safe = false
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires = 
     async-exit-stack;python_version<'3.7'
     async-generator;python_version<'3.7'
@@ -49,3 +49,7 @@ where = src
 [options.entry_points]
 console_scripts =
     datarest = datarest.cli:cli
+
+[yapf]
+indent_closing_brackets = true
+#align_closing_bracket_with_visual_indent = true

--- a/src/datarest/_data_resource_models.py
+++ b/src/datarest/_data_resource_models.py
@@ -1,6 +1,3 @@
-import json
-from typing import List 
-
 import frictionless
 from sqlmodel import Field
 
@@ -14,18 +11,18 @@ tableschema_type_map = {
     'integer': int,
     'complex': complex,
     'boolean': bool
-    }
+}
 
 
 def create_model(model_name, model_def):
     resource = frictionless.Resource(model_def.schema_)
     (id_columns, model) = create_model_from_tableschema(
-        model_name, schema=resource['schema'])
+        model_name, schema=resource.schema)
     return (id_columns, model)
 
 
 def create_model_from_tableschema(model_name, schema):
-    id_columns = schema['primaryKey']
+    id_columns = schema.primary_key
     # The tableschema spec allows for both a list or a string for the
     # primaryKey attribute, we make it a tuple.
     if isinstance(id_columns, str):
@@ -34,29 +31,29 @@ def create_model_from_tableschema(model_name, schema):
         id_columns = tuple(id_columns)
 
     id_default_func = _resource_ids.create_id_default(
-        id_type=schema['x_datarest_primary_key_info']['id_type'],
+        id_type=schema.custom['x_datarest_primary_key_info']['id_type'],
         primary_key=tuple(
-            schema['x_datarest_primary_key_info']['id_src_fields']),
-        )
+            schema.custom['x_datarest_primary_key_info']['id_src_fields']),
+    )
 
     attributes = {}
-    for field_def in schema['fields']:
-        name = field_def['name']
-        typ = tableschema_type_map[field_def['type']]
+    for field_def in schema.fields:
+        name = field_def.name
+        typ = tableschema_type_map[field_def.type]
         # optional
         primary_key = True if name in id_columns else False
-        description = field_def.get('description')
-        example = field_def.get('example')
+        description = field_def.description
+        example = field_def.example
         sa_column_kwargs = {}
         if primary_key and id_default_func is not None:
             sa_column_kwargs['default'] = id_default_func
         attributes[name] = (
-            typ, 
+            typ,
             Field(description=description,
                   primary_key=primary_key,
                   schema_extra={'example': example},
                   sa_column_kwargs=sa_column_kwargs)
-            )
+        )
     model = _sqlmodel_ext.create_model(
         model_name, __cls_kwargs__={'table': True},  **attributes)
     return (id_columns, model)

--- a/src/datarest/_data_resource_tools.py
+++ b/src/datarest/_data_resource_tools.py
@@ -6,7 +6,8 @@ import re
 import frictionless
 
 from ._resource_ids import (
-    IdEnum, id_type_funcs,
+    IdEnum,
+    id_type_funcs,
     )
 
 
@@ -34,10 +35,6 @@ def add_examples(resource):
     # dict-unpacking doesn't reliably work with Row objects, see
     # https://github.com/frictionlessdata/frictionless-py/issues/1152
     resource = add_attr(resource, attr_name='example', **example_row.to_dict())
-
-    # Reading data from a resource adds stats information to the resource
-    # object, which we don't need. So remove it.
-    resource.pop('stats')
     return resource
 
 
@@ -62,30 +59,36 @@ def normalize_field_names(resource, prefix='f_'):
 
 def normalize_headers_step(prefix='f_'):
     """Normalize resource header field names to valid identifiers.
-    
+
     Custom frictionless transform step.
-    
+
     Parameters:
         prefix: Add prefix to field names that start with a numeric character
             after character substitution.
     """
+
     def step(resource):
         # a frictionless resource transform step to normalize headers
         current = resource.to_copy()
         # Meta
         resource.data = current.data
         normalize_field_names(resource, prefix=prefix)
-        return step 
+        return step
 
 
 def composite_id_step(
-        id_, id_type, primary_key, field_names, id_field_name='id_',
-        concat_sep='.'):
+        id_,
+        id_type,
+        primary_key,
+        field_names,
+        id_field_name='id_',
+        concat_sep='.'
+    ):
     """Create a resource transform step using the provided id_ generation
     callable.
 
     Custom frictionless transform step.
-    
+
     Parameters:
         id_: a callable id_(*fields, concat_sep) to generate a unique ID
         id_type: a _resource_ids.IdEnum
@@ -97,39 +100,45 @@ def composite_id_step(
     # Get the given PK field indexes for use in the transform step
     pk_indexes = [
         i for (i, field_name) in enumerate(field_names)
-        if field_name in set(primary_key)]
+        if field_name in set(primary_key)
+        ]
 
-    def step(resource):
-        # a frictionless resource transform step to add a single field 
-        # resource id from the primary key fields
+    class _composite_id_step(frictionless.Step):
 
-        current = resource.to_copy()
-        # Data
-        def data():
-            with current:
-                for line in current.list_stream:
-                    # can't use operator.itemgetter here since it doesn't
-                    # always return tuples but a single value for a single
-                    # index arg
-                    pk_fields = (line[i] for i in pk_indexes)
-                    composite_id = id_(*pk_fields, concat_sep=concat_sep)
-                    line.insert(0, composite_id)
-                    yield line
+        def transform_resource(self, resource):
+            # a frictionless resource transform step to add a single field
+            # resource id from the primary key fields
 
-        # Meta
-        resource.data = data
-        resource.schema.fields.insert(
-            0,
-            frictionless.Field(
-                name=id_field_name, type='string',
-                description='Unique resource id')
-            )
-        resource.schema.primary_key = [id_field_name]
-        resource.schema['x_datarest_primary_key_info'] = {
-            'id_type': str(id_type),
-            'id_src_fields': list(primary_key)
-            }
-    return step
+            current = resource.to_copy()
+
+            # Data
+
+            def data():
+                with current:
+                    for line in current.cell_stream:
+                        # can't use operator.itemgetter here since it doesn't
+                        # always return tuples but a single value for a single
+                        # index arg
+                        pk_fields = (line[i] for i in pk_indexes)
+                        composite_id = id_(*pk_fields, concat_sep=concat_sep)
+                        line.insert(0, composite_id)
+                        yield line
+
+            # Meta
+            resource.data = data
+            resource.schema.fields.insert(
+                0,
+                frictionless.fields.StringField(
+                    name=id_field_name, description='Unique resource id'
+                    )
+                )
+            resource.schema.primary_key = [id_field_name]
+            resource.schema.custom['x_datarest_primary_key_info'] = {
+                'id_type': str(id_type),
+                'id_src_fields': list(primary_key)
+                }
+
+    return _composite_id_step
 
 
 def primary_key_step(
@@ -138,41 +147,51 @@ def primary_key_step(
         primary_key=(),
         create_exposed=False,
         id_field_name='id_',
-        concat_sep='.'):
+        concat_sep='.'
+    ):
     """Return a custom frictionless resource transform step to add a single
     primary key field to a given resource.
     """
     fields = resource.schema.fields
     field_names = resource.schema.field_names
     if not primary_key:
-        primary_key = (fields[0].name,)
+        primary_key = (fields[0].name, )
     primary_key_set = set(primary_key)
     if not primary_key_set <= set(field_names):
         raise ValueError(
             f'Primary key fields {primary_key} not a subset of table fields '
-            f'{field_names}')
-    
+            f'{field_names}'
+            )
+
     if id_type == IdEnum.biz_key:
         if len(primary_key) > 1:
             raise ValueError(
-                f'Composite primary key not supported for ID type {id_type}')
-        pk_field = fields.get_field(name=primary_key[0])
+                f'Composite primary key not supported for ID type {id_type}'
+                )
+        pk_field = resource.schema.get_field(name=primary_key[0])
         if create_exposed and pk_field.type not in ['integer']:
             raise ValueError(
-                f'ID type {id_type} must be integer if data create is exposed')
+                f'ID type {id_type} must be integer if data create is exposed'
+                )
 
-        def step(resource):
-            current = resource.to_copy()
-            # Meta
-            resource.schema.primary_key = list(primary_key)
+        class _primary_key_step(frictionless.Step):
 
-        return step
+            def transform_resource(self, resource):
+                # Meta
+                resource.schema.primary_key = list(primary_key)
+                resource.schema.custom['x_datarest_primary_key_info'] = {
+                    'id_type': str(id_type),
+                    'id_src_fields': list(primary_key)
+                    }
+
+        return _primary_key_step
 
     else:
         if id_field_name in field_names:
             raise ValueError(
                 f'ID field name {id_field_name} conflicts with existing field '
-                f'name')
+                f'name'
+                )
 
         id_ = id_type_funcs[id_type]
 
@@ -182,7 +201,8 @@ def primary_key_step(
             primary_key=primary_key,
             field_names=field_names,
             id_field_name=id_field_name,
-            concat_sep=concat_sep) 
+            concat_sep=concat_sep
+            )
 
         return step
 


### PR DESCRIPTION
Main necessary changes for adapting to frictionless v5:

- MetaData base class is not a dict anymore so no item-based access; use attribute-based access throughout
- Use schema.custom to set non-standard tableschema extensions
- Custom steps are generally class-based now, on frictionless.Step, and must provide the 
  transform_resource(self, resource) method
- Use formats.SqlControl API instead of SqlDialect
- Use StringField(...) instead of Field(..., type="string")

Additionally:
- Add missing x_datarest_... custom schema setting for primary key type "biz_key"
- Fix erroneous get_field access 